### PR TITLE
Small patch allowing inline choices for select

### DIFF
--- a/js/bootstrap-editable.js
+++ b/js/bootstrap-editable.js
@@ -346,7 +346,7 @@
                   }
               }
 
-              if(typeof this.settings.source == 'string' ) { //ajax loading from server
+              if(typeof this.settings.source == 'string' && this.settings.source[0] !== '{' ) { //ajax loading from server
                   $.ajax({
                       url: this.settings.source, 
                       type: 'get',
@@ -363,6 +363,9 @@
                       }
                   });
               } else {
+                  if (typeof this.settings.source == 'string') {
+                      this.settings.source = eval('e='+this.settings.source);
+                  }
                   setOptions(this.settings.source);
                   this.endShow();
               }


### PR DESCRIPTION
In case the choices are constant I can now write:

```
<a [...] type="select" data-source="{'L':'Low', '': 'None', 'M': 'Medium', 'H': 'High'}">My content</a>
```

However, allowing js:some_code() could be a better (more flexible) alternative, but I doubt it's supported as well.
