### PR TITLE
show emptytext for toggled fields as well

### DIFF
--- a/src/js/bootstrap-editable.js
+++ b/src/js/bootstrap-editable.js
@@ -401,11 +401,6 @@
         },
 
         handleEmpty:function () {
-            //don't have editalbe class --> it's not link --> toggled by another element --> no need to set emptytext
-            if (!this.$element.hasClass('editable')) {
-                return;
-            }
-
             if ($.trim(this.$element.text()) === '') {
                 this.$element.addClass('editable-empty').text(this.settings.emptytext);
             } else {


### PR DESCRIPTION
Even if the field is toggled by another element, I still want to show some default text if the field is empty.
