### PR TITLE
Allow users to set a custom send method

### DIFF
--- a/src/js/bootstrap-editable.js
+++ b/src/js/bootstrap-editable.js
@@ -305,6 +305,10 @@
                     params.pk = pk;
                 }
 
+                if(typeof this.settings.sendMethod === 'function'){
+                    return this.settings.sendMethod(params);
+                }
+
                 //send ajax to server and return deferred object
                 return $.ajax({
                     url     : (typeof this.settings.url === 'function') ? this.settings.url.call(this) : this.settings.url,


### PR DESCRIPTION
While integrating bootstrap-editable into a backbone project, I found it very restrictive in terms of how it syncs to your backend server. Not everyone can or wants to accept a POST with the params pk, name, and value.

I added the option 'sendMethod', which, if defined && a function, overrides the $.ajax call in Editable.send.

This allows me to reuse my existing sync methods and write code like:

```
this.$el.find(".list-btn a").editable({
  name: "ShortListName",
  sendMethod: function(params){
    var shortList = me.lists.get(params.pk);
    shortList.rename(params.value);
  }
});
```
