### PR TITLE
Fixes for new bootstrap versions

### DIFF
--- a/src/js/bootstrap-editable.js
+++ b/src/js/bootstrap-editable.js
@@ -143,7 +143,8 @@
                 this.$element.popover({
                     trigger  :'manual',
                     placement:'top',
-                    content  :this.settings.loading
+                    content  :this.settings.loading,
+                    html: true
                 });
 
                 this.$element.data('popover').tip().addClass('editable-popover');
@@ -168,7 +169,7 @@
                 this.$content.find('div.control-group').prepend(this.$input);
 
                 //invoke form into popover content
-                $tip.find('.popover-content p').append(this.$content);
+                $tip.find('.popover-content').append(this.$content);
                 
                 //set position once more. It is required to pre-move popover when it is close to screen edge.
                 this.setPosition();


### PR DESCRIPTION
2.0.3:
Try to autodetect when to use html/text method in tooltip/popovers to help prevent xss
(added html option for popover)

2.2.2:
Plugin no longer inserts popover content into a <p>, but rather directly into .popover-content.
